### PR TITLE
Accept autorestart parameter

### DIFF
--- a/templates/app.ini.j2
+++ b/templates/app.ini.j2
@@ -5,6 +5,8 @@ stdout_logfile={{ log_dir|replace("~", "%(ENV_HOME)s") }}/{{ name }}.out.log
 stderr_logfile={{ log_dir|replace("~", "%(ENV_HOME)s") }}/{{ name }}.err.log
 autostart={% if autostart %}true{% else %}false{% endif %}
 
+autorestart={% if autorestart %}{{autorestart}}{% else %}unexpected{% endif %}
+
 numprocs={{ numprocs }}
 user={{ user }}
 stopwaitsecs={{ stopwaitsecs }}


### PR DESCRIPTION
needed an empty line in between otherwise jade will put autostart and autorestart on the same line :-/
